### PR TITLE
feat/#50 : 프론트와 이미지 업로드 API 연동

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -33,9 +33,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-
 ALLOWED_HOSTS = ['*']
-
 
 # Application definition
 
@@ -214,7 +212,13 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES':(
         'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser'
     )
+
 }
 
 SIMPLE_JWT = {

--- a/plants/storagess.py
+++ b/plants/storagess.py
@@ -33,6 +33,7 @@ class MyS3Client:
         try:
             print(str(file))
             file_id    = 'images/'+str(uuid.uuid4())+'.png'
+            file_name = str(uuid.uuid4())+'.png'
             extra_args = { 'ContentType' : file.content_type }
             print(extra_args)
             
@@ -42,7 +43,8 @@ class MyS3Client:
                     file_id,
                     ExtraArgs = extra_args
                 )
-            return f'https://{self.bucket_name}.s3.ap-northeast-2.amazonaws.com/{file_id}'
+            #return f'https://{self.bucket_name}.s3.ap-northeast-2.amazonaws.com/{file_id}'
+            return f'{file_name}'
         except :
             return None
 

--- a/plants/views.py
+++ b/plants/views.py
@@ -10,12 +10,11 @@ from .tasks import plantsAi
 import os, shutil, uuid, boto3
 from pathlib import Path
 from dotenv import load_dotenv
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated,AllowAny
 from rest_framework.decorators import permission_classes
 import jwt
 from django.conf import settings
 # from djangorestframework_simplejwt.tokens import AccessToken
-
 
 load_dotenv()
 AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY')
@@ -23,12 +22,11 @@ AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY')
 AWS_REGION = os.environ.get('AWS_REGION')
 S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME')
 
-
 # Create your views here.
 
 @csrf_exempt
 @api_view(['POST'])
-@permission_classes([IsAuthenticated])
+@permission_classes([AllowAny]) 
 def s3Upload(request) :
     file = request.FILES['picture']
     profile_image_url = FileUpload(s3_client).upload(file)


### PR DESCRIPTION
## 추가한 기능 설명

- 이미지 업로드에 필요한 Parser 추가 -> settings.py
- s3 url 반환값을 이미지의 이름으로 변경
-  jwt 인증 방식 변경 -> api 연동이 아직 안된 관계로 s3Upload부분을 잠시 AllowAny로 변경 

<br>

## check list

- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
